### PR TITLE
Removing link to solana-info repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ A: If you've followed the [setup instructions](https://docs.solanalabs.com/opera
 ```sudo bash -c 'echo performance > /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor'```
 
 ## Resources
-- [https://github.com/valigator-tech/solana-info?tab=readme-ov-file](https://github.com/valigator-tech/solana-info?tab=readme-ov-file)
 - [Useful links to tools for validators](https://gist.github.com/ferric-sol/451fbb55e34d1df04c0dcc7556f95cb6)
 
 ## Contributors


### PR DESCRIPTION
I have not been able to maintain this repo so I think we should remove it from the HCL.

I'll send a PR in the future to add it back if I get around to it.