### PR TITLE
Add TR7975WX for FD

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ With each CPU it was tested if its possible to catch up with a non-voting node, 
 | Yes         | **AMD**      | EPYC 7742                     |   2.25 GHz |  Up to 3.40 GHz |    64 |     128 |       225 W | Yes, default layout  | Yes, default layout  |
 | Yes         | **AMD**      | EPYC 7513                     |   2.60 GHz |  Up to 3.65 GHz |    32 |      64 |       200 W | Yes, default layout  | Not tested yet       |
 | Yes         | **AMD**      | EPYC 74F3                     |   3.20 GHz |  Up to 4.00 GHz |    24 |      48 |       240 W | Yes, default layout  | Yes, default layout  |
+| Yes         | **AMD**      | Ryzen Threadripper Pro 7975WX |   4.00 GHz |  Up to 5.30 GHz |    32 |      64 |       350 W | Yes, default layout  | Yes, default layout  |
 | Yes         | **AMD**      | Ryzen Threadripper Pro 7965WX |   4.20 GHz |  Up to 5.30 GHz |    24 |      48 |       350 W | Yes, default layout  | Yes, default layout  |
 | No          | **AMD**      | Ryzen 9 5900X                 |   3.70 GHz |  Up to 4.80 GHz |    12 |      24 |       105 W | Yes, custom layout*  | No                   |
 | No          | **AMD**      | Ryzen 9 5950X                 |   3.40 GHz |  Up to 4.90 GHz |    16 |      32 |       105 W | Yes, default layout  | -                    |


### PR DESCRIPTION
Hey, 
here is the details about the TR7975WX when I tried it on the mainnet with FD : 

sol@fd-mn-1:~$ cat log/firedancer.log | grep "speed check"
INFO    2025-07-16 13:22:53.893386226 GMT+00   4232:4233   sol:fd-mn-1:f0   fd1:[group]:agave core/src/validator.rs(2254)[solana_core::validator]: PoH speed check: computed hashes per second 15087453, target hashes per second 10000000
INFO    2025-07-16 13:54:00.258780848 GMT+00  53851:53852  sol:fd-mn-1:f0   fd1:[group]:agave core/src/validator.rs(2254)[solana_core::validator]: PoH speed check: computed hashes per second 18053795, target hashes per second 10000000


I put it near the TR7965WX on the FD table. I noticed performance was worst than with an EPYC9374F but similar than TR7965WX.

I did not test it on testnet but I suppose it would work fine if mainnet is good.

If you need more info, do not hesitate to send me a message.

Best,

Léo