### PR TITLE
Update Broadcom BCM57416 NIC: bnxt driver lacks XDP zero-copy support

### DIFF
--- a/src/data/network.ts
+++ b/src/data/network.ts
@@ -33,7 +33,7 @@ export const networkCards: NetworkCard[] = [
         speed: '10 GbE',
         ports: 2,
         media: 'copper',
-        notes: 'Common in OEM servers. Basic XDP support.'
+        notes: "Common in OEM servers. Basic XDP support. Driver 'bnxt' does NOT support XDP zero-copy."
     },
 ];
 


### PR DESCRIPTION
update the notes to reflect that the NIC/driver does not support XDP zero-copy. it may be better to remove the BCM57416 entry entirely as the notes aren't visible on the webpage.

reference discussion validator-hw-tuning: https://discord.com/channels/428295358100013066/811317327609856081/1492946788817305660